### PR TITLE
Fix version reference in README / Makefile & Actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 phony: help
 
 # Release tag for the action
-VERSION := v0.3
+VERSION := 0.3
 
 # GitHub Actions bogus variables
 GITHUB_REF ?= refs/heads/null

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Main action is using [wata727](https://github.com/wata727)'s [TFLint](https://gi
 
 ```yaml
     - name: Run the Action
-      uses: devops-infra/action-tflint@v0.3
+      uses: devops-infra/action-tflint@0.3
       with:
         dir_filter: modules
 ```
@@ -63,7 +63,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Check linting of Terraform files
-      uses: devops-infra/action-tflint@v0.3
+      uses: devops-infra/action-tflint@0.3
 ```
 
 Use different location for TFLint config file and parse only `aws*` and `gcp*` modules in `modules/` directory. Run the Action via GitHub.
@@ -80,7 +80,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Check linting of Terraform modules
-      uses: devops-infra/action-tflint@v0.3
+      uses: devops-infra/action-tflint@0.3
       with:
         tflint_config: modules/.tflint.hcl
         dir_filter: modules/aws,modules/gcp
@@ -100,7 +100,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Check linting of Terraform modules
-      uses: devops-infra/action-tflint@v0.3
+      uses: devops-infra/action-tflint@0.3
       with:
         tflint_params: "--module --deep"
         dir_filter: modules

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     default: "true"
 runs:
   using: docker
-  image: docker://devopsinfra/action-tflint:v0.3
+  image: docker://devopsinfra/action-tflint:0.3
 branding:
   color: purple
   icon: upload-cloud


### PR DESCRIPTION
Tags don't have `v` prefix. Use just raw number.

## :memo:  Brief description

<!-- Write you description here -->

<!-- Diff summary - START -->
<!-- Diff summary - END -->


## :computer:  Commits
<!-- Diff commits - START -->
<!-- Diff commits - END -->


## :file_folder:  Modified files
<!-- Diff files - START -->
<!-- Diff files - END -->


## :warning: Additional information
* [ ] Pushed to a branch with a proper name and provided proper commit message.
* [ ] Provided a clear and concise description of what the issue is.


*Check [CONTRIBUTING.md](https://github.com/devops-infra/.github/blob/master/CONTRIBUTING.md) and
[CODE_OF_CONDUCT.md](https://github.com/devops-infra/.github/blob/master/CODE_OF_CONDUCT.md) for more information*
