### PR TITLE
Adds tflint --init invoke

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,12 +19,12 @@ for PREFIX in "${ARRAY[@]}"; do
           if [[ "${INPUT_RUN_INIT}" == "true" ]]; then
             terraform init
           fi
-          tflint -c "${WORK_DIR}/${INPUT_TFLINT_CONFIG}" || RET_CODE=1
+          tflint --init && tflint -c "${WORK_DIR}/${INPUT_TFLINT_CONFIG}" || RET_CODE=1
         else
           if [[ "${INPUT_RUN_INIT}" == "true" ]]; then
             terraform init
           fi
-          tflint "${INPUT_TFLINT_PARAMS}" || RET_CODE=1
+          tflint --init && tflint "${INPUT_TFLINT_PARAMS}" || RET_CODE=1
         fi
         cd "${WORK_DIR}" || RET_CODE=1
     done


### PR DESCRIPTION
## :memo:  Brief description

Starting from v0.35.0, `tflint` does not include bundled plugins. `tflint --init` is needed to install all plugins defined in config file.

<!-- Diff summary - START -->
<!-- Diff summary - END -->


## :computer:  Commits
<!-- Diff commits - START -->
<!-- Diff commits - END -->


## :file_folder:  Modified files
<!-- Diff files - START -->
<!-- Diff files - END -->


## :warning: Additional information
* [x] Pushed to a branch with a proper name and provided proper commit message.
* [x] Provided a clear and concise description of what the issue is.


*Check [CONTRIBUTING.md][contributing] and [CODE_OF_CONDUCT.md][code] for more information*

[contributing]: https://github.com/devops-infra/.github/blob/master/CONTRIBUTING.md
[code]: https://github.com/devops-infra/.github/blob/master/CODE_OF_CONDUCT.md
